### PR TITLE
fix(login-dismiss)

### DIFF
--- a/Dizzy/Coordinators/LoginCoordinator.swift
+++ b/Dizzy/Coordinators/LoginCoordinator.swift
@@ -59,7 +59,8 @@ extension LoginCoordinator: LoginVMNavigationDelegate, SignInWithDizzyVMNavigati
         container?.autoregister(DizzyUser.self, initializer: {
             return user
         })
-        closePressed()
+        
+        navigationController.popToRootViewController(animated: true)
     }
     
     func closePressed() {


### PR DESCRIPTION
The bug: when user login successfully it dismissing the menu
expected result: pop to login menu after user logged in successfully